### PR TITLE
Fix ci

### DIFF
--- a/.github/get_published_version.sh
+++ b/.github/get_published_version.sh
@@ -4,12 +4,22 @@
 # nuget list "id:JBSnorro" # doesn't hang
 # $(nuget list "id:JBSnorro") # hangs 🤷‍ in VS wsl in Developer Powershell window (but not in VSCode terminal)
 
-version=$(nuget list "id:JBSnorro" | sed 's/JBSnorro//' | xargs | tr -d '\n' | tr -d '\r')
-# xargs trims. tr trims newlines
+version=$(nuget list "id:JBSnorro"   \
+        | grep '\bJBSnorro\s'        \
+        | grep -v 'JBSnorro.Testing' \
+        | sed 's/JBSnorro//'         \
+        | xargs                      \
+        | tr -d '\n'                 \
+        | tr -d '\r'                 )
+# grep tries to exclude other JBSnorro patters. sed strips JBSnorro. xargs trims. tr trims newlines
 
-if [ -z $version ]; then
-    echo "fatal: No version found"
-    exit 1
+if [ -z "$version" ]; then
+    echo "fatal: No version found";
+    exit 1;
 fi
 
+if [ -z $(echo "$version" | grep -Pe '[0-9\.]+') ]; then
+    echo "fatal: Invalid version found: $version";
+    exit 1;
+fi
 echo "$version"


### PR DESCRIPTION
Since now we have a `JBSnorro.Testing` library on nuget, the previous code parsing the version failed, with version `0.0.13 .Testing 0.0.1`, which should have been `0.0.13`.