### PR TITLE
Use test account integration tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Prepare ssh access
       run: |
           mkdir "$(dirname "$SSH_FILE")"
-          echo "${{ secrets.PLAYGROUND_SSH_KEY }}" > "$SSH_FILE"
+          echo "${{ secrets.JEROENBOS_TESTSERVICEUSER_SSH_KEY }}" > "$SSH_FILE"
           
           # Give access to ssh key (Linux)
           if [[ '${{ matrix.os }}' == 'ubuntu-latest' ]]; then

--- a/JBSnorro.Tests/Git/GitTests.cs
+++ b/JBSnorro.Tests/Git/GitTests.cs
@@ -22,7 +22,7 @@ namespace JBSnorro.Csx.Tests
     [TestCategory("Integration")]
     public class GitTestsBase
     {
-        protected const string ROOT_HASH = "818c7ad1722e9c4fe682b30ade4413bf1e36c542";
+        protected const string ROOT_HASH = "56f98d2dbf26e00ddd74479250a00a5a8fc25ec3";
 
         // if SSH_FILE cannot be found:
         // - in testing, add JBSnorro.Tests/Properties/.runSettings as VS -> Test -> Configure Run Settings -> Select ...
@@ -72,7 +72,7 @@ namespace JBSnorro.Csx.Tests
             string dir = dirDisposable.Value;
             this.cleanup = dirDisposable.WithBefore(() => CleanupSSHAgent(dir));
 
-            var result = await "git init; git config user.name 'tester'; git config user.email 'tester@test.com'".Execute(cwd: dir);
+            var result = await "git init; git config user.name 'JeroenBos-TestServiceUser'; git config user.email 'tester@test.com'; git config init.defaultBranch main; ".Execute(cwd: dir);
 
             Assert.AreEqual(result.ExitCode, 0, result.ErrorOutput);
             Assert.IsTrue(result.StandardOutput.StartsWith("Initialized empty Git repository"));
@@ -90,6 +90,8 @@ namespace JBSnorro.Csx.Tests
             var repo = await InitEmptyRepo(remoteFactory);
             var result = await "git commit --allow-empty -m 'First commit'".Execute(cwd: repo.Dir);
             Assert.IsTrue(result.StandardOutput.EndsWith("First commit"));
+            result = await "git checkout -b main; git branch -D master".Execute(cwd: repo.Dir);
+            Assert.IsTrue(result.StandardOutput.Contains("Deleted branch master"));
             return repo;
         }
         protected async Task<IGitRepo> InitRepoWithUntrackedFile()
@@ -175,7 +177,7 @@ namespace JBSnorro.Csx.Tests
                 await $"sudo chmod 600 {ssh_file}".Execute(cwd: repo.Dir); // or just execute manually if I ever reinstalled Windows or something
                 (exitCode, stdOut, stdErr) = await $"source ../startup.sh && ssh-add {ssh_file}".Execute(cwd: repo.Dir);
             }
-            (exitCode, stdOut, stdErr) = await "git remote add origin git@github.com:JeroenBos/TestPlayground.git".Execute(cwd: repo.Dir);
+            (exitCode, stdOut, stdErr) = await "git remote add origin git@github.com:JeroenBos-TestServiceUser/TestPlayground.git".Execute(cwd: repo.Dir);
             Assert.AreEqual((exitCode, stdOut, stdErr), (0, "", ""));
 
             try
@@ -195,14 +197,20 @@ namespace JBSnorro.Csx.Tests
                                     .Where(line => !line.StartsWith("warning", StringComparison.OrdinalIgnoreCase)) // "warning: no common commits", and "Warning: Permanently added the RSA host ..."
                                     .ToArray();
             Assert.IsTrue(stdErrLines[0].StartsWith("Identity added"));
-            Assert.IsTrue(stdErrLines[1].StartsWith("From github.com:JeroenBos/TestPlayground"), stdErrLines[1]);
-            Assert.IsTrue(stdErrLines[2].StartsWith(" * [new branch]      master     -> origin/master"), stdErrLines[2]);
+            // var (e, o, er) = await $"{SSH_SCRIPT} && git init && git commit --allow-empty -nm 'Initial commit' && git branch -M main".Execute(cwd: repo.Dir);
+            // Assert.AreEqual(e, 0);
 
-            (exitCode, stdOut, stdErr) = await $"{SSH_SCRIPT} && git branch --set-upstream-to=origin/master master".Execute(cwd: repo.Dir);
+            // var (e2, o2, er2) = await $"{SSH_SCRIPT} && git remote add origin git@github.com:JeroenBos-TestServiceUser/Testplayground.git && git push -u origin main".Execute(cwd: repo.Dir);
+            // Assert.AreEqual(e2, 0);
+
+            Assert.IsTrue(stdErrLines[1].StartsWith("From github.com:JeroenBos-TestServiceUser/TestPlayground"), stdErrLines[1]);
+            Assert.IsTrue(stdErrLines[2].StartsWith(" * [new branch]      main       -> origin/main"), stdErrLines[2]);
+
+            (exitCode, stdOut, stdErr) = await $"{SSH_SCRIPT} && git branch --set-upstream-to=origin/main main".Execute(cwd: repo.Dir);
             Assert.AreEqual(exitCode, 0);
             // the following depends on git version or something:
-            Assert.IsTrue(stdOut.IsAnyOf("Branch 'master' set up to track remote branch 'master' from 'origin'.",
-                                         "branch 'master' set up to track 'origin/master'."), stdOut);
+            Assert.IsTrue(stdOut.IsAnyOf("Branch 'main' set up to track remote branch 'main' from 'origin'.",
+                                         "branch 'main' set up to track 'origin/main'."), stdOut);
             Assert.AreEqual(stdErr.Split('\n').Length, 1);
             Assert.IsTrue(stdErr.StartsWith("Identity added"));
 
@@ -211,7 +219,7 @@ namespace JBSnorro.Csx.Tests
             Assert.AreEqual(stdOut.Split('\n').Length, 1);
             Assert.IsTrue(stdOut.StartsWith("HEAD is now at"));
 
-            // this can throw with error containing "! [remote rejected] master -> master (cannot lock ref 'refs/heads/master'"
+            // this can throw with error containing "! [remote rejected] main -> main (cannot lock ref 'refs/heads/main'"
             // it's presumably due to parallelism, but that shouldn't be there :/
             (exitCode, stdOut, stdErr) = await $"{SSH_SCRIPT} && git fetch && git push --force-with-lease".Execute(cwd: repo.Dir);
             Assert.AreEqual((exitCode, stdOut), (0, ""), message: stdErr);
@@ -570,7 +578,7 @@ namespace JBSnorro.Csx.Tests
 
             var branchName = await repo.GetPRBaseBranch("1");
 
-            Assert.AreEqual("origin/master", branchName);
+            Assert.AreEqual("origin/main", branchName);
         }
     }
     class RemoteRepoWithNoUpdates : IRemoteGitRepo


### PR DESCRIPTION
Changes repository and test user, to prevent me from accidentally using the user's credentials (which somehow sometimes lingered on) to committing to real repositories.