### PR TITLE
Fix publish

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -61,10 +61,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish
-        if: ${{ env.PUBLISH == 'true' }}
+        if: ${{ env.PUBLISH == 'true' }} # 🚧
         run: dotnet nuget push                                              \
                     ./JBSnorro/bin/Release/JBSnorro.*.symbols.nupkg         \
                     --api-key ${{ secrets.NUGET_API_KEY }}                  \
-                    --source https://api.nuget.org/v3/index.json            \
+                    --source 'https://api.nuget.org/v3/index.json'          \
                     --skip-duplicate
           

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -14,11 +14,10 @@ defaults:
     shell: bash
 jobs:
   publish:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
         include:
         - project: JBSnorro
           workflowName: CI
@@ -63,9 +62,9 @@ jobs:
 
       - name: Publish
         if: ${{ env.PUBLISH == 'true' && github.ref == 'refs/heads/main' }}
-        uses: alirezanet/publish-nuget@v3.0.4 # atm, this bugfix is not merged yet: https://github.com/brandedoutcast/publish-nuget/pull/62
-        with:
-          PROJECT_FILE_PATH: ${{ env.CSPROJ_PATH }}
-          INCLUDE_SYMBOLS: true
-          NUGET_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push                                              \
+                    ./JBSnorro/bin/Release/JBSnorro.*.symbols.nupkg         \
+                    --api-key ${{ secrets.NUGET_API_KEY }}                  \
+                    --source https://api.nuget.org/v3/index.json            \
+                    --skip-duplicate
           

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -35,12 +35,13 @@ jobs:
           published_version=$(bash .github/get_published_version.sh '${{ matrix.project }}' | xargs)
           echo "published_version: \"$published_version\""
 
-          if [[ "$current_version" == "$published_version" ]]; then
-              echo "Up-to-date"
-          else
+          # 🚧
+          # if [[ "$current_version" == "$published_version" ]]; then
+          #     echo "Up-to-date"
+          # else
               echo "PUBLISH=true" >> $GITHUB_ENV
               echo "Publishing"
-          fi
+          # fi
 
 
       - name: Setup .NET Core

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -35,13 +35,12 @@ jobs:
           published_version=$(bash .github/get_published_version.sh '${{ matrix.project }}' | xargs)
           echo "published_version: \"$published_version\""
 
-          # 🚧
-          # if [[ "$current_version" == "$published_version" ]]; then
-          #     echo "Up-to-date"
-          # else
+          if [[ "$current_version" == "$published_version" ]]; then
+              echo "Up-to-date"
+          else
               echo "PUBLISH=true" >> $GITHUB_ENV
               echo "Publishing"
-          # fi
+          fi
 
 
       - name: Setup .NET Core
@@ -54,14 +53,14 @@ jobs:
         if: ${{ env.PUBLISH == 'true' }}
         run: dotnet build --configuration Release
 
-      #- name: Wait for CI
-      #  uses: deepinsight-io/action-wait-on-workflow@v2.1.1
-      #  if: ${{ env.PUBLISH == 'true' }}
-      #  with:
-      #    workflowName: ${{ matrix.workflowName }}
-      #    token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Wait for CI
+        uses: deepinsight-io/action-wait-on-workflow@v2.1.1
+        if: ${{ env.PUBLISH == 'true' }}
+        with:
+          workflowName: ${{ matrix.workflowName }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish
-        if: ${{ env.PUBLISH == 'true' }} # 🚧
+        if: ${{ env.PUBLISH == 'true' && github.ref == 'refs/heads/main' }}
         run: dotnet nuget push "./JBSnorro/bin/Release/JBSnorro.*.symbols.nupkg" -k '${{ secrets.NUGET_API_KEY }}' -s 'https://api.nuget.org/v3/index.json'
                     

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -65,6 +65,6 @@ jobs:
         run: dotnet nuget push                                              \
                     ./JBSnorro/bin/Release/JBSnorro.*.symbols.nupkg         \
                     --api-key ${{ secrets.NUGET_API_KEY }}                  \
-                    --source 'https://api.nuget.org/v3/index.json'          \
+                    -s "https://api.nuget.org/v3/index.json"                \
                     --skip-duplicate
           

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -54,12 +54,12 @@ jobs:
         if: ${{ env.PUBLISH == 'true' }}
         run: dotnet build --configuration Release
 
-      - name: Wait for CI
-        uses: deepinsight-io/action-wait-on-workflow@v2.1.1
-        if: ${{ env.PUBLISH == 'true' }}
-        with:
-          workflowName: ${{ matrix.workflowName }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+      #- name: Wait for CI
+      #  uses: deepinsight-io/action-wait-on-workflow@v2.1.1
+      #  if: ${{ env.PUBLISH == 'true' }}
+      #  with:
+      #    workflowName: ${{ matrix.workflowName }}
+      #    token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish
         if: ${{ env.PUBLISH == 'true' }} # 🚧

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -65,6 +65,5 @@ jobs:
         if: ${{ env.PUBLISH == 'true' }} # 🚧
         run: dotnet nuget push                                              \
                     --api-key ${{ secrets.NUGET_API_KEY }}                  \
-                    --source 'https://api.nuget.org/v3/index.json'          \
                     --skip-duplicate                                        \
                     "./JBSnorro/bin/Release/JBSnorro.*.symbols.nupkg"

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -63,7 +63,5 @@ jobs:
 
       - name: Publish
         if: ${{ env.PUBLISH == 'true' }} # 🚧
-        run: dotnet nuget push                                              \
-                    --api-key ${{ secrets.NUGET_API_KEY }}                  \
-                    --skip-duplicate                                        \
-                    "./JBSnorro/bin/Release/JBSnorro.*.symbols.nupkg"
+        run: dotnet nuget push "./JBSnorro/bin/Release/JBSnorro.*.symbols.nupkg" -k '${{ secrets.NUGET_API_KEY }}' -s 'https://api.nuget.org/v3/index.json'
+                    

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -63,5 +63,8 @@ jobs:
 
       - name: Publish
         if: ${{ env.PUBLISH == 'true' }} # 🚧
-        run: dotnet nuget push "./JBSnorro/bin/Release/JBSnorro.*.symbols.nupkg" -k '${{ secrets.NUGET_API_KEY }}' -s 'https://api.nuget.org/v3/index.json'
+        run: dotnet nuget push \
+                    "./JBSnorro/bin/Release/JBSnorro.*.symbols.nupkg" \
+                    -k '${{ secrets.NUGET_API_KEY }}' \
+                    -s 'https://api.nuget.org/v3/index.json'
                     

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -63,4 +63,3 @@ jobs:
       - name: Publish
         if: ${{ env.PUBLISH == 'true' && github.ref == 'refs/heads/main' }}
         run: dotnet nuget push "./JBSnorro/bin/Release/JBSnorro.*.symbols.nupkg" -k '${{ secrets.NUGET_API_KEY }}' -s 'https://api.nuget.org/v3/index.json'
-                    

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -61,7 +61,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish
-        if: ${{ env.PUBLISH == 'true' && github.ref == 'refs/heads/main' }}
+        if: ${{ env.PUBLISH == 'true' }}
         run: dotnet nuget push                                              \
                     ./JBSnorro/bin/Release/JBSnorro.*.symbols.nupkg         \
                     --api-key ${{ secrets.NUGET_API_KEY }}                  \

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -63,8 +63,5 @@ jobs:
 
       - name: Publish
         if: ${{ env.PUBLISH == 'true' }} # 🚧
-        run: dotnet nuget push \
-                    "./JBSnorro/bin/Release/JBSnorro.*.symbols.nupkg" \
-                    -k '${{ secrets.NUGET_API_KEY }}' \
-                    -s 'https://api.nuget.org/v3/index.json'
+        run: dotnet nuget push "./JBSnorro/bin/Release/JBSnorro.*.symbols.nupkg" -k '${{ secrets.NUGET_API_KEY }}' -s 'https://api.nuget.org/v3/index.json'
                     

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -64,8 +64,7 @@ jobs:
       - name: Publish
         if: ${{ env.PUBLISH == 'true' }} # 🚧
         run: dotnet nuget push                                              \
-                    ./JBSnorro/bin/Release/JBSnorro.*.symbols.nupkg         \
                     --api-key ${{ secrets.NUGET_API_KEY }}                  \
-                    -s "https://api.nuget.org/v3/index.json"                \
-                    --skip-duplicate
-          
+                    --source 'https://api.nuget.org/v3/index.json'          \
+                    --skip-duplicate                                        \
+                    "./JBSnorro/bin/Release/JBSnorro.*.symbols.nupkg"

--- a/JBSnorro.sln
+++ b/JBSnorro.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		.github\workflows\CI.Testing.yml = .github\workflows\CI.Testing.yml
 		.github\workflows\CI.yml = .github\workflows\CI.yml
+		.github\workflows\Publish.yml = .github\workflows\Publish.yml
 		test.runsettings = test.runsettings
 		test.runsettings.example = test.runsettings.example
 	EndProjectSection


### PR DESCRIPTION
- JBSnorro v0.0.16 didn't get published. The matrix include only seems to execute the last one 🤔
- Fixes `set-output` deprecation warnings