### PR TITLE
Workaround bug

### DIFF
--- a/JBSnorro.Tests/Extensions/FileExtensionsTests.cs
+++ b/JBSnorro.Tests/Extensions/FileExtensionsTests.cs
@@ -1,9 +1,7 @@
 ﻿using JBSnorro;
 using JBSnorro.Diagnostics;
 using JBSnorro.Extensions;
-using JBSnorro.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Diagnostics;
 using TaskExtensions = JBSnorro.Extensions.TaskExtensions;
 
 namespace Tests.JBSnorro.Extensions;
@@ -40,7 +38,7 @@ public class FileExtensionsTests
         // Act
         async Task reader(CancellationToken cancellationToken)
         {
-            await foreach (var line in FileExtensions.ReadAllLinesContinuously(path, isDone, cancellationToken))
+            await foreach (var line in FileExtensions.ReadAllLinesContinuously(path, enableDelayed: false, isDone, cancellationToken))
             {
                 readLines.Add(line);
             }

--- a/JBSnorro.Tests/Extensions/FileExtensionsTests.cs
+++ b/JBSnorro.Tests/Extensions/FileExtensionsTests.cs
@@ -11,6 +11,24 @@ public class FileExtensionsTests
 {
     const int step_ms = 500;
     const int timeout_ms = 10 * step_ms + 5000 /* because in CI it's rather slow */;
+    [TestMethod]
+    public async Task TestReadAllLinesContinuouslyAThousandTimes()
+    {
+        var start = DateTime.Now;
+        while (DateTime.Now <= start + TimeSpan.FromMinutes(6))
+        {
+            Console.Write(".");
+            try
+            {
+                await TestReadAllLinesContinuously();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.ToString());
+                throw;
+            }
+        }
+    }
     [TestMethod, Timeout(timeout_ms)]
     public async Task TestReadAllLinesContinuously()
     {

--- a/JBSnorro.Tests/Extensions/FileExtensionsTests.cs
+++ b/JBSnorro.Tests/Extensions/FileExtensionsTests.cs
@@ -11,24 +11,6 @@ public class FileExtensionsTests
 {
     const int step_ms = 500;
     const int timeout_ms = 10 * step_ms + 5000 /* because in CI it's rather slow */;
-    [TestMethod]
-    public async Task TestReadAllLinesContinuouslyAThousandTimes()
-    {
-        var start = DateTime.Now;
-        while (DateTime.Now <= start + TimeSpan.FromMinutes(6))
-        {
-            Console.Write(".");
-            try
-            {
-                await TestReadAllLinesContinuously();
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex.ToString());
-                throw;
-            }
-        }
-    }
     [TestMethod, Timeout(timeout_ms)]
     public async Task TestReadAllLinesContinuously()
     {


### PR DESCRIPTION
`FileSystemWatcher.Changed` does not trigger unless I delay `EnableRaisingEvents = true` 🤷‍♂️