### PR TITLE
Fix more nuget CI issues

### DIFF
--- a/.github/get_published_version.sh
+++ b/.github/get_published_version.sh
@@ -9,19 +9,16 @@ if [[ "$#" -ne 1 ]]; then
     exit 1;
 fi
 
-output="$(nuget list "packageid:$1")"
+output="$(nuget search "packageid:$1" -Verbosity quiet -Source nuget.org)"
 if [[ $? -ne 0 ]]; then
     echo $output
     exit 1
 fi
 
-version="$(echo "$output"                    \
-         | sed "s/$1//"                      \
-         | xargs                             \
-         | sed -e 's/^[[:space:]]*//'        \
-         | tr -d '\n'                        \
-         | tr -d '\r'                        )"
-# sed strips package name. xargs trims. sed -e trims leading spaces because xargs doesn't trim leading spaces 🤷‍, tr trims newlines
+version="$(echo "$output"               \
+         | grep '>'                     \
+         | cut -d '|' -f2               \
+         | tr -d '[:space:]'            )"
 
 if [[ "$version" == "No packages found." ]]; then
     echo "fatal: No version of '$1' found"

--- a/.github/workflows/CI.Testing.yml
+++ b/.github/workflows/CI.Testing.yml
@@ -10,7 +10,7 @@ on:
     - '**.md'
 
 env:
-  DOTNET_VERSION: 7.0.102  # select a 'sdk'.'version' from https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/releases.json
+  DOTNET_VERSION: 7.0.410  # select a 'sdk'.'version' from https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/releases.json
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 defaults:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 env:
-  DOTNET_VERSION: 7.0.102  # select a 'sdk'.'version' from https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/releases.json
+  DOTNET_VERSION: 7.0.410  # select a 'sdk'.'version' from https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/releases.json
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 defaults:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-    - '**.md'
-    - 'JBSnorro.Testing/**'
-    - 'JBSnorro.Testing.Tests/**'
+      - '**.md'
+      - 'JBSnorro.Testing/**'
+      - 'JBSnorro.Testing.Tests/**'
   pull_request:
     paths-ignore:
-    - '**.md'
-    - 'JBSnorro.Testing/**'
-    - 'JBSnorro.Testing.Tests/**'
+      - '**.md'
+      - 'JBSnorro.Testing/**'
+      - 'JBSnorro.Testing.Tests/**'
 
 env:
-    DOTNET_VERSION: 7.0.102  # select a 'sdk'.'version' from https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/releases.json
-    DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_VERSION: 7.0.102  # select a 'sdk'.'version' from https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/releases.json
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 defaults:
   run:
@@ -25,37 +25,37 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
-          configuration: Debug
-        - os: ubuntu-latest
-          configuration: Release
-        - os: windows-latest
-          configuration: Debug
+          - os: ubuntu-latest
+            configuration: Debug
+          - os: ubuntu-latest
+            configuration: Release
+          - os: windows-latest
+            configuration: Debug
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
 
     - name: Create dummy runsettings file
       # in CI env vars are passed in directly, so the runsettings file can be empty
       run: echo '<RunSettings></RunSettings>' > test.runsettings
-         
-    - name: Create NODE_PATH env var
-      run: echo "NODE_PATH=$(which node)$([[ '${{ matrix.os }}' == 'windows-latest' ]] && echo -n '.exe')" >> $GITHUB_ENV 
 
-    - name: Create SSH_FILE env var 
+    - name: Create NODE_PATH env var
+      run: echo "NODE_PATH=$(which node)$([[ '${{ matrix.os }}' == 'windows-latest' ]] && echo -n '.exe')" >> $GITHUB_ENV
+
+    - name: Create SSH_FILE env var
       run: echo "SSH_FILE=$HOME/.ssh/playground" >> $GITHUB_ENV
 
     - name: Prepare ssh access
       run: |
           mkdir "$(dirname "$SSH_FILE")"
           echo "${{ secrets.JEROENBOS_TESTSERVICEUSER_SSH_KEY }}" > "$SSH_FILE"
-          
+
           # Give access to ssh key (Linux)
           if [[ '${{ matrix.os }}' == 'ubuntu-latest' ]]; then
               sudo chmod 600 "$SSH_FILE"
@@ -83,4 +83,3 @@ jobs:
     - name: Unit test + integration tests
       if: ${{ steps.should-test-gh.outputs.all_changed_and_modified_files }}
       run: dotnet test JBSnorro.Tests/JBSnorro.Tests.csproj --configuration ${{ matrix.configuration }}
-

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,10 +8,6 @@ on:
       - 'JBSnorro.Testing/**'
       - 'JBSnorro.Testing.Tests/**'
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'JBSnorro.Testing/**'
-      - 'JBSnorro.Testing.Tests/**'
 
 env:
   DOTNET_VERSION: 7.0.102  # select a 'sdk'.'version' from https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/releases.json

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,14 +4,18 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-      - '**.md'
-      - 'JBSnorro.Testing/**'
-      - 'JBSnorro.Testing.Tests/**'
+    - '**.md'
+    - 'JBSnorro.Testing/**'
+    - 'JBSnorro.Testing.Tests/**'
   pull_request:
+    paths-ignore:
+    - '**.md'
+    - 'JBSnorro.Testing/**'
+    - 'JBSnorro.Testing.Tests/**'
 
 env:
-  DOTNET_VERSION: 7.0.410  # select a 'sdk'.'version' from https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/releases.json
-  DOTNET_CLI_TELEMETRY_OPTOUT: true
+    DOTNET_VERSION: 7.0.410  # select a 'sdk'.'version' from https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/releases.json
+    DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 defaults:
   run:
@@ -21,37 +25,37 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
-            configuration: Debug
-          - os: ubuntu-latest
-            configuration: Release
-          - os: windows-latest
-            configuration: Debug
+        - os: ubuntu-latest
+          configuration: Debug
+        - os: ubuntu-latest
+          configuration: Release
+        - os: windows-latest
+          configuration: Debug
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+    - uses: actions/checkout@v3
+    - uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
 
     - name: Create dummy runsettings file
       # in CI env vars are passed in directly, so the runsettings file can be empty
       run: echo '<RunSettings></RunSettings>' > test.runsettings
-
+         
     - name: Create NODE_PATH env var
-      run: echo "NODE_PATH=$(which node)$([[ '${{ matrix.os }}' == 'windows-latest' ]] && echo -n '.exe')" >> $GITHUB_ENV
+      run: echo "NODE_PATH=$(which node)$([[ '${{ matrix.os }}' == 'windows-latest' ]] && echo -n '.exe')" >> $GITHUB_ENV 
 
-    - name: Create SSH_FILE env var
+    - name: Create SSH_FILE env var 
       run: echo "SSH_FILE=$HOME/.ssh/playground" >> $GITHUB_ENV
 
     - name: Prepare ssh access
       run: |
           mkdir "$(dirname "$SSH_FILE")"
           echo "${{ secrets.JEROENBOS_TESTSERVICEUSER_SSH_KEY }}" > "$SSH_FILE"
-
+          
           # Give access to ssh key (Linux)
           if [[ '${{ matrix.os }}' == 'ubuntu-latest' ]]; then
               sudo chmod 600 "$SSH_FILE"
@@ -79,3 +83,4 @@ jobs:
     - name: Unit test + integration tests
       if: ${{ steps.should-test-gh.outputs.all_changed_and_modified_files }}
       run: dotnet test JBSnorro.Tests/JBSnorro.Tests.csproj --configuration ${{ matrix.configuration }}
+

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -5,14 +5,14 @@ on:
     branches: [main]
     paths-ignore:
       - "**.md"
-  pull_request:  # do a dry-run in PRs
+  pull_request: # do a dry-run in PRs
     paths:
       - ".github/workflows/Publish.yml"
       - ".github/get_published_version.sh"
       - ".github/get_current_version.sh"
 
 env:
-  LANG: 'C.UTF-8'  # necessary for grep on Windows
+  LANG: 'C.UTF-8'  # necessary for grep on Windows    
 defaults:
   run:
     shell: bash
@@ -23,10 +23,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - project: JBSnorro
-            workflowName: CI
-          - project: JBSnorro.Testing
-            workflowName: CI (JBSnorro.Testing)
+        - project: JBSnorro
+          workflowName: CI
+        - project: JBSnorro.Testing
+          workflowName: CI (JBSnorro.Testing)
     env:
       CSPROJ_PATH: '${{ matrix.project }}/${{ matrix.project }}.csproj'
       

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -38,8 +38,17 @@ jobs:
         run: |
           current_version=$(bash .github/get_current_version.sh "${CSPROJ_PATH}" | xargs)
           echo "current_version: \"$current_version\""
+          if ! [[ "$current_version" =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
+            echo "An invalid current version was found"
+            exit 1
+          fi
+
           published_version=$(bash .github/get_published_version.sh "$PROJECT" | xargs)
           echo "published_version: \"$published_version\""
+          if ! [[ "$published_version" =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
+            echo "An invalid published version was found"
+            exit 1
+          fi
 
           if [[ "$current_version" == "$published_version" ]]; then
               echo "Up-to-date"

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -39,14 +39,14 @@ jobs:
           current_version=$(bash .github/get_current_version.sh "${CSPROJ_PATH}" | xargs)
           echo "current_version: \"$current_version\""
           if ! [[ "$current_version" =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
-            echo "An invalid current version was found"
+            echo "Error: An invalid current version was found"
             exit 1
           fi
 
           published_version=$(bash .github/get_published_version.sh "$PROJECT" | xargs)
           echo "published_version: \"$published_version\""
           if ! [[ "$published_version" =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
-            echo "An invalid published version was found"
+            echo "Error: An invalid published version was found"
             exit 1
           fi
 

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -5,14 +5,14 @@ on:
     branches: [main]
     paths-ignore:
       - "**.md"
-  pull_request: # do a dry-run in PRs
+  pull_request:  # do a dry-run in PRs
     paths:
       - ".github/workflows/Publish.yml"
       - ".github/get_published_version.sh"
       - ".github/get_current_version.sh"
 
 env:
-  LANG: 'C.UTF-8'  # necessary for grep on Windows    
+  LANG: 'C.UTF-8'  # necessary for grep on Windows
 defaults:
   run:
     shell: bash
@@ -23,10 +23,10 @@ jobs:
     strategy:
       matrix:
         include:
-        - project: JBSnorro
-          workflowName: CI
-        - project: JBSnorro.Testing
-          workflowName: CI (JBSnorro.Testing)
+          - project: JBSnorro
+            workflowName: CI
+          - project: JBSnorro.Testing
+            workflowName: CI (JBSnorro.Testing)
     env:
       CSPROJ_PATH: '${{ matrix.project }}/${{ matrix.project }}.csproj'
       


### PR DESCRIPTION
The `nuget list` command got deprecated, and so that started printing a warning, which threw a spanner in the works.

Using the `nuget search` (recommended) instead now